### PR TITLE
fix: use corrected Wi-Fi coordinates

### DIFF
--- a/custom_components/yqt/core/protocol.py
+++ b/custom_components/yqt/core/protocol.py
@@ -424,6 +424,17 @@ def build_watch_state(
     latitude = coerce_float(first_row.get("lat"))
     longitude = coerce_float(first_row.get("lng"))
 
+    if abs(coerce_int(first_row.get("datatype")) or 0) == 3:
+        corrected_latitude = coerce_float(first_row.get("lat_co"))
+        corrected_longitude = coerce_float(first_row.get("lng_co"))
+        if (
+            corrected_latitude is not None
+            and corrected_longitude is not None
+            and (corrected_latitude != 0 or corrected_longitude != 0)
+        ):
+            latitude = corrected_latitude
+            longitude = corrected_longitude
+
     if latitude == 0 and longitude == 0:
         if previous is not None:
             return replace(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -116,6 +116,46 @@ class ApiHelpersTestCase(unittest.TestCase):
         self.assertEqual(current.latitude, previous.latitude)
         self.assertEqual(current.longitude, previous.longitude)
 
+    def test_build_watch_state_uses_corrected_wifi_position(self) -> None:
+        current = build_watch_state(
+            make_watch(),
+            {
+                "status": 1,
+                "data": [
+                    {
+                        "datatype": "3",
+                        "lat": "50.0",
+                        "lng": "5.0",
+                        "lat_co": "50.1",
+                        "lng_co": "5.1",
+                    }
+                ],
+            },
+        )
+
+        self.assertEqual(current.latitude, 50.1)
+        self.assertEqual(current.longitude, 5.1)
+
+    def test_build_watch_state_falls_back_from_invalid_wifi_correction(self) -> None:
+        current = build_watch_state(
+            make_watch(),
+            {
+                "status": 1,
+                "data": [
+                    {
+                        "datatype": "3",
+                        "lat": "50.0",
+                        "lng": "5.0",
+                        "lat_co": "0",
+                        "lng_co": "0",
+                    }
+                ],
+            },
+        )
+
+        self.assertEqual(current.latitude, 50.0)
+        self.assertEqual(current.longitude, 5.0)
+
     def test_build_watch_state_keeps_previous_location_metadata_on_zero_zero_position(self) -> None:
         watch = make_watch()
         previous = YQTWatchState(


### PR DESCRIPTION
## Summary
- use corrected coordinates for Wi-Fi positions when available
- fall back to the existing raw coordinates when the correction is missing or invalid

## Tests
- `uv run --python /opt/homebrew/bin/python3 --with 'cryptography>=42.0.0' --with aiohttp python -m unittest discover -s tests`
- `/opt/homebrew/bin/python3 -m compileall -q custom_components/yqt tests`

Fixes #8
