### PR TITLE
fix: handle offline location requests

### DIFF
--- a/custom_components/yqt/coordinator.py
+++ b/custom_components/yqt/coordinator.py
@@ -10,13 +10,8 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import DOMAIN, POLL_INTERVAL, REQUEST_LOCATION_REFRESH_DELAY
 from .core.async_client import YQTApiClient
-from .core.protocol import (
-    DEVICE_OFFLINE_STATUS,
-    YQTAuthError,
-    YQTError,
-    YQTResponseError,
-    YQTWatchState,
-)
+from .core.protocol import DEVICE_OFFLINE_STATUS
+from .core.protocol import YQTAuthError, YQTError, YQTResponseError, YQTWatchState
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,14 +42,11 @@ class YQTDataUpdateCoordinator(DataUpdateCoordinator[dict[str, YQTWatchState]]):
             raise ConfigEntryAuthFailed(str(exc)) from exc
         except YQTResponseError as exc:
             if exc.status == DEVICE_OFFLINE_STATUS:
-                state = self.data.get(did) if self.data else None
-                name = state.watch.name if state else did
                 persistent_notification.async_create(
                     self.hass,
-                    f"The location request for {name} could not be delivered. "
-                    "Check the device's coverage or settings.",
-                    title=f"{name} is offline",
-                    notification_id=f"{DOMAIN}_{did}_offline",
+                    exc.message,
+                    f"{self.data[did].watch.name} is offline",
+                    f"{DOMAIN}_{did}_offline",
                 )
                 return
             raise UpdateFailed(str(exc)) from exc

--- a/custom_components/yqt/coordinator.py
+++ b/custom_components/yqt/coordinator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+from homeassistant.components import persistent_notification
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.event import async_call_later
@@ -9,7 +10,13 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import DOMAIN, POLL_INTERVAL, REQUEST_LOCATION_REFRESH_DELAY
 from .core.async_client import YQTApiClient
-from .core.protocol import YQTAuthError, YQTError, YQTWatchState
+from .core.protocol import (
+    DEVICE_OFFLINE_STATUS,
+    YQTAuthError,
+    YQTError,
+    YQTResponseError,
+    YQTWatchState,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,9 +45,23 @@ class YQTDataUpdateCoordinator(DataUpdateCoordinator[dict[str, YQTWatchState]]):
             await self.client.async_request_location(did)
         except YQTAuthError as exc:
             raise ConfigEntryAuthFailed(str(exc)) from exc
+        except YQTResponseError as exc:
+            if exc.status == DEVICE_OFFLINE_STATUS:
+                state = self.data.get(did) if self.data else None
+                name = state.watch.name if state else did
+                persistent_notification.async_create(
+                    self.hass,
+                    f"The location request for {name} could not be delivered. "
+                    "Check the device's coverage or settings.",
+                    title=f"{name} is offline",
+                    notification_id=f"{DOMAIN}_{did}_offline",
+                )
+                return
+            raise UpdateFailed(str(exc)) from exc
         except YQTError as exc:
             raise UpdateFailed(str(exc)) from exc
 
+        persistent_notification.async_dismiss(self.hass, f"{DOMAIN}_{did}_offline")
         self._async_schedule_delayed_refresh()
 
     @callback

--- a/custom_components/yqt/core/async_client.py
+++ b/custom_components/yqt/core/async_client.py
@@ -38,6 +38,11 @@ from .transport import (
 )
 
 
+COMMAND_ERROR_MESSAGES = {
+    601: "Device is offline. Check coverage or settings.",
+}
+
+
 class YQTApiClient:
     def __init__(
         self,
@@ -343,8 +348,17 @@ class YQTApiClient:
         if status in SUCCESS_STATUSES:
             return
 
-        message = str(payload.get("message", payload.get("msg", "unexpected command response")))
-        raise YQTResponseError(code if code is not None else status, message, payload)
+        error_status = code if code is not None else status
+        message = str(
+            payload.get(
+                "message",
+                payload.get(
+                    "msg",
+                    COMMAND_ERROR_MESSAGES.get(error_status, "unexpected command response"),
+                ),
+            )
+        )
+        raise YQTResponseError(error_status, message, payload)
 
     @staticmethod
     def _ensure_login_success(payload: dict[str, Any]) -> None:

--- a/custom_components/yqt/core/async_client.py
+++ b/custom_components/yqt/core/async_client.py
@@ -9,10 +9,11 @@ from urllib.parse import urljoin
 import aiohttp
 
 from .protocol import (
-    COMMAND_ERROR_MESSAGES,
     DEFAULT_APP_ID,
     DEFAULT_CLIENT_FLAG,
     DEFAULT_CLIENT_VERSION,
+    DEVICE_OFFLINE_MESSAGE,
+    DEVICE_OFFLINE_STATUS,
     DEFAULT_IS_IPHONE,
     DEFAULT_LANGUAGE,
     DEFAULT_SIGN_FLAG,
@@ -345,15 +346,12 @@ class YQTApiClient:
             return
 
         error_status = code if code is not None else status
-        message = str(
-            payload.get(
-                "message",
-                payload.get(
-                    "msg",
-                    COMMAND_ERROR_MESSAGES.get(error_status, "unexpected command response"),
-                ),
-            )
+        fallback = (
+            DEVICE_OFFLINE_MESSAGE
+            if error_status == DEVICE_OFFLINE_STATUS
+            else "unexpected command response"
         )
+        message = str(payload.get("message", payload.get("msg", fallback)))
         raise YQTResponseError(error_status, message, payload)
 
     @staticmethod

--- a/custom_components/yqt/core/async_client.py
+++ b/custom_components/yqt/core/async_client.py
@@ -9,6 +9,7 @@ from urllib.parse import urljoin
 import aiohttp
 
 from .protocol import (
+    COMMAND_ERROR_MESSAGES,
     DEFAULT_APP_ID,
     DEFAULT_CLIENT_FLAG,
     DEFAULT_CLIENT_VERSION,
@@ -36,11 +37,6 @@ from .transport import (
     decrypt_response,
     encrypt_request,
 )
-
-
-COMMAND_ERROR_MESSAGES = {
-    601: "Device is offline. Check coverage or settings.",
-}
 
 
 class YQTApiClient:

--- a/custom_components/yqt/core/protocol.py
+++ b/custom_components/yqt/core/protocol.py
@@ -16,9 +16,7 @@ DEFAULT_SIGN_FLAG = "KHDIW"
 SIGN_PREFIX = "SECRPRO"
 SUCCESS_STATUSES = {1, 4}
 DEVICE_OFFLINE_STATUS = 601
-COMMAND_ERROR_MESSAGES = {
-    DEVICE_OFFLINE_STATUS: "Device is offline. Check coverage or settings.",
-}
+DEVICE_OFFLINE_MESSAGE = "Device is offline. Check coverage or settings."
 DEVICE_META_KEYS = (
     "didstr",
     "didrole",

--- a/custom_components/yqt/core/protocol.py
+++ b/custom_components/yqt/core/protocol.py
@@ -15,6 +15,10 @@ DEFAULT_IS_IPHONE = 1
 DEFAULT_SIGN_FLAG = "KHDIW"
 SIGN_PREFIX = "SECRPRO"
 SUCCESS_STATUSES = {1, 4}
+DEVICE_OFFLINE_STATUS = 601
+COMMAND_ERROR_MESSAGES = {
+    DEVICE_OFFLINE_STATUS: "Device is offline. Check coverage or settings.",
+}
 DEVICE_META_KEYS = (
     "didstr",
     "didrole",

--- a/custom_components/yqt/core/sync_client.py
+++ b/custom_components/yqt/core/sync_client.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from .protocol import (
+    COMMAND_ERROR_MESSAGES,
     DEFAULT_APP_ID,
     DEFAULT_CLIENT_FLAG,
     DEFAULT_CLIENT_VERSION,
@@ -23,6 +24,7 @@ from .protocol import (
     YQTHTTPError,
     YQTResponseError,
     build_watch_index,
+    coerce_int,
     compute_sign,
     hash_password,
     photo_wall_filename,
@@ -654,14 +656,24 @@ class YQTClient:
 
     @staticmethod
     def _ensure_command_success(payload: dict[str, Any]) -> None:
-        code = payload.get("code")
+        code = coerce_int(payload.get("code"))
         if code == 200:
             return
-        if isinstance(payload.get("status"), int):
-            YQTClient._ensure_success(payload)
+        status = coerce_int(payload.get("status"))
+        if status in SUCCESS_STATUSES:
             return
-        message = str(payload.get("message", payload.get("msg", "unknown command response")))
-        raise YQTResponseError(code if isinstance(code, int) else None, message, payload)
+
+        error_status = code if code is not None else status
+        message = str(
+            payload.get(
+                "message",
+                payload.get(
+                    "msg",
+                    COMMAND_ERROR_MESSAGES.get(error_status, "unknown command response"),
+                ),
+            )
+        )
+        raise YQTResponseError(error_status, message, payload)
 
     @staticmethod
     def _ensure_status(payload: dict[str, Any], allowed_statuses: set[int]) -> None:

--- a/custom_components/yqt/core/sync_client.py
+++ b/custom_components/yqt/core/sync_client.py
@@ -11,10 +11,11 @@ from pathlib import Path
 from typing import Any
 
 from .protocol import (
-    COMMAND_ERROR_MESSAGES,
     DEFAULT_APP_ID,
     DEFAULT_CLIENT_FLAG,
     DEFAULT_CLIENT_VERSION,
+    DEVICE_OFFLINE_MESSAGE,
+    DEVICE_OFFLINE_STATUS,
     DEFAULT_IS_IPHONE,
     DEFAULT_LANGUAGE,
     DEFAULT_SIGN_FLAG,
@@ -24,7 +25,6 @@ from .protocol import (
     YQTHTTPError,
     YQTResponseError,
     build_watch_index,
-    coerce_int,
     compute_sign,
     hash_password,
     photo_wall_filename,
@@ -656,28 +656,21 @@ class YQTClient:
 
     @staticmethod
     def _ensure_command_success(payload: dict[str, Any]) -> None:
-        code = coerce_int(payload.get("code"))
+        code = payload.get("code")
         if code == 200:
             return
-        status = coerce_int(payload.get("status"))
-        if status in SUCCESS_STATUSES:
+        status = payload.get("status")
+        if isinstance(status, int):
+            YQTClient._ensure_success(payload)
             return
-
-        error_status = code if code is not None else status
-        message = str(
-            payload.get(
-                "message",
-                payload.get(
-                    "msg",
-                    COMMAND_ERROR_MESSAGES.get(error_status, "unknown command response"),
-                ),
-            )
-        )
-        raise YQTResponseError(error_status, message, payload)
+        fallback = DEVICE_OFFLINE_MESSAGE if code == DEVICE_OFFLINE_STATUS else "unknown command response"
+        message = str(payload.get("message", payload.get("msg", fallback)))
+        raise YQTResponseError(code if isinstance(code, int) else None, message, payload)
 
     @staticmethod
     def _ensure_status(payload: dict[str, Any], allowed_statuses: set[int]) -> None:
         status = payload.get("status")
         if status not in allowed_statuses:
-            message = str(payload.get("message", "unknown server response"))
+            fallback = DEVICE_OFFLINE_MESSAGE if status == DEVICE_OFFLINE_STATUS else "unknown server response"
+            message = str(payload.get("message", payload.get("msg", fallback)))
             raise YQTResponseError(status if isinstance(status, int) else None, message, payload)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,6 +12,7 @@ from custom_components.yqt.const import DOMAIN
 from custom_components.yqt.core.async_client import YQTApiClient
 from custom_components.yqt.core.protocol import (
     REGIONS,
+    YQTResponseError,
     YQTWatch,
     YQTWatchState,
     build_watch_index,
@@ -422,6 +423,20 @@ class TransportTestCase(unittest.TestCase):
 
 
 class AsyncClientTransportTestCase(unittest.IsolatedAsyncioTestCase):
+    def test_command_status_601_is_described_as_offline(self) -> None:
+        for payload in ({"code": 601}, {"status": 601}):
+            with (
+                self.subTest(payload=payload),
+                self.assertRaises(YQTResponseError) as raised,
+            ):
+                YQTApiClient._ensure_command_success(payload)
+
+            self.assertEqual(raised.exception.status, 601)
+            self.assertEqual(
+                raised.exception.message,
+                "Device is offline. Check coverage or settings.",
+            )
+
     async def test_ssl_context_is_created_off_event_loop(self) -> None:
         context = object()
         context_threads: list[int] = []

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -426,18 +426,15 @@ class TransportTestCase(unittest.TestCase):
 class AsyncClientTransportTestCase(unittest.IsolatedAsyncioTestCase):
     def test_command_status_601_is_described_as_offline(self) -> None:
         for client in (YQTApiClient, YQTClient):
-            for payload in ({"code": 601}, {"status": 601}):
+            for key in ("code", "status"):
                 with (
-                    self.subTest(client=client.__name__, payload=payload),
-                    self.assertRaises(YQTResponseError) as raised,
+                    self.subTest(client=client.__name__, key=key),
+                    self.assertRaisesRegex(
+                        YQTResponseError,
+                        "status=601: Device is offline",
+                    ),
                 ):
-                    client._ensure_command_success(payload)
-
-                self.assertEqual(raised.exception.status, 601)
-                self.assertEqual(
-                    raised.exception.message,
-                    "Device is offline. Check coverage or settings.",
-                )
+                    client._ensure_command_success({key: 601})
 
     async def test_ssl_context_is_created_off_event_loop(self) -> None:
         context = object()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,6 +21,7 @@ from custom_components.yqt.core.protocol import (
     DEFAULT_CLIENT_VERSION,
     is_login_timeout_response,
 )
+from custom_components.yqt.core.sync_client import YQTClient
 from custom_components.yqt.core.transport import (
     CLIENT_CERTIFICATE,
     create_ssl_context,
@@ -424,18 +425,19 @@ class TransportTestCase(unittest.TestCase):
 
 class AsyncClientTransportTestCase(unittest.IsolatedAsyncioTestCase):
     def test_command_status_601_is_described_as_offline(self) -> None:
-        for payload in ({"code": 601}, {"status": 601}):
-            with (
-                self.subTest(payload=payload),
-                self.assertRaises(YQTResponseError) as raised,
-            ):
-                YQTApiClient._ensure_command_success(payload)
+        for client in (YQTApiClient, YQTClient):
+            for payload in ({"code": 601}, {"status": 601}):
+                with (
+                    self.subTest(client=client.__name__, payload=payload),
+                    self.assertRaises(YQTResponseError) as raised,
+                ):
+                    client._ensure_command_success(payload)
 
-            self.assertEqual(raised.exception.status, 601)
-            self.assertEqual(
-                raised.exception.message,
-                "Device is offline. Check coverage or settings.",
-            )
+                self.assertEqual(raised.exception.status, 601)
+                self.assertEqual(
+                    raised.exception.message,
+                    "Device is offline. Check coverage or settings.",
+                )
 
     async def test_ssl_context_is_created_off_event_loop(self) -> None:
         context = object()


### PR DESCRIPTION
## Summary

- describe command response 601 consistently in the async and synchronous clients
- treat an offline location request as an expected Home Assistant result instead of a WebSocket service error
- create or update one persistent offline notification per watch
- dismiss that notification after a later successful location request
- preserve messages returned by the server

## Testing

- 18 unit tests pass
- Python modules compile successfully
- isolated coordinator check confirms notification create, dismiss, and refresh behavior